### PR TITLE
mmc/offline.sh: Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Example: `http://user:password@ip:8080/cgi-bin/motor.cgi?dir=right&dist=10`
 
 I put together rather quickly and did not do a lot of testing so try it out and feel free to review the source (motor.c)
 
+#### Offline mode
+In `custom.sh` uncomment the line calling for `offline.sh` (leave the condition in front!)
+It has been reported to break the application.
+
+Other choice for advances users: Block directly the firewall (and kill existing states!) *once* the camera is started (camera doesn't start without internet because of time configuration. Looks like it is not standard NTP protocol).
+
 #### Final note
 
 If you'd like more details about the whole process or have any issues, open an issue in github and we can discuss it further!

--- a/mmc/custom.sh
+++ b/mmc/custom.sh
@@ -11,3 +11,8 @@ if [ ! -e /tmp/cleanup`date +%Y%m%d` ]; then
  touch /tmp/cleanup`date +%Y%m%d`
  /tmp/sd/cgi-bin/cleanup.cgi > /tmp/cleanup.log
 fi
+
+
+## if offline.sh is not running, run it
+#[[ ! `pgrep -f offline.sh` ]] && /tmp/sd/offline.sh &
+

--- a/mmc/hosts
+++ b/mmc/hosts
@@ -1,0 +1,4 @@
+127.0.0.1   localhost:localdomain   localhost
+127.0.0.1 a.tuyaus.com a2.tuyaus.com a3.tuyaus.com m2.tuyaus.com mq.gw.tuyaus.com s.tuyaus.com
+127.0.0.1 a.tuyacn.com a2.tuyacn.com a3.tuyacn.com m2.tuyacn.com mq.gw.tuyacn.com s.tuyacn.com
+127.0.0.1 a.tuyaeu.com a2.tuyaeu.com a3.tuyaeu.com m2.tuyaeu.com mq.gw.tuyaeu.com s.tuyaeu.com

--- a/mmc/offline.sh
+++ b/mmc/offline.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+echo "${0}: starting $(date)" >> /tmp/offline.log
+
+# If no hosts file, leave
+if [ ! -e /tmp/sd/hosts ]; then
+ echo "${0}: no hosts file found on card. Not doing anything" >> /tmp/offline.log
+ exit 0
+fi
+
+# Wait for date to be corrected
+while [ `date +%s` -lt 1645543474 ]; do
+ date >> /tmp/offline.log
+ sleep 1
+done
+
+# Block internet access to tuya servers
+if [ "$(mount | grep -c /etc/hosts)" -eq "0" ]; then
+  mount --bind /tmp/sd/hosts /etc/hosts 2>&1 >> /tmp/offline.log
+fi
+echo "${0}: blocked hosts" >> /tmp/offline.log
+# Wait for connection to be dropped
+while [ `netstat -ntu 2>&1 | grep -v 127.0.0.1 | grep -v ":24\|:554\|:6668" | grep -c ESTABLISHED` -gt 0 ]; do
+ # For each non-telnet established IP
+ #   port 24 : telnet
+ #   port 554: rtsp stream
+ #   port 6668: app stream
+ for ip in `netstat -ntu 2>&1 | grep -v 127.0.0.1 | grep -v ":24\|:554\|:6668" | grep ESTABLISHED | awk '{print $5}' | awk -F: '{print $1}'`; do
+  echo "${0}: checking $ip" >> /tmp/offline.log
+  if [ "`route -n | grep -c $ip`" == "0" ]; then
+   route add -net $ip netmask 255.255.255.255 gw 127.0.0.1  2>&1 >> /tmp/offline.log
+   echo "${0}: blocked $ip" >> /tmp/offline.log
+  fi
+ done
+done
+
+echo "${0} done $(date)" >> /tmp/offline.log


### PR DESCRIPTION
Follow up on https://github.com/guino/LSCOutdoor1080P/issues/4#issuecomment-1690437350 
This PR adds the offline script (taken from previous camera work) and adapt it for this model 

Be aware that it seems to break the application in some cases ! (at the beginning, my app was _always_ retrieving the flux from tuya's servers. Now, it seems to use local only)

line `[[ ! `pgrep -f offline.sh` ]] && /tmp/sd/offline.sh &` is needed because the script is called from `custom.sh` which is itself called every 10 seconds. 

I made this choice because I fear, in the previous versions, running it only once is not enough : 
Once the tuya connection is dropped, it will attempt to use another IP address which will not be blacklisted. With this version, every 10 sec new connections will be dropped as null routed. 

However, it might be a flaw in this script because of the `grep -v 6668` which is a grep on the source port of `anyka_ipc` daemon. 
In *theory* this should be fine as source port 6668 is used for rtsp and source port 6667 is used for Tuya. 